### PR TITLE
Fixed `addons.cson` and `package.json` to work with Atom 1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "version": "0.4.0",
   "private": false,
   "description": "A snippet boost for Bourbon.io & Neat.bourbon.io users",
-  "activationEvents": [
-    "jack-n-coke:toggle"
-  ],
+  "activationCommands": {
+    "atom-workspace": ["jack-n-coke:toggle"]
+  },
   "repository": "https://github.com/samuelhorn/jack-n-coke/",
   "license": "MIT",
   "engines": {

--- a/snippets/addons.cson
+++ b/snippets/addons.cson
@@ -25,13 +25,13 @@
         "body": "@include hide-text;"
     "all text inputs":
         "prefix": "all-text-inputs"
-        "body":'"#{$all-text-inputs} { border: 1px solid green; }'
+        "body": "\#\{\$all-text-inputs} { border: 1px solid green; }"
     "all text inputs hover":
         "prefix": "all-text-inputs-hover"
-        "body": '#{$all-text-inputs-hover} { background: yellow; }'
+        "body": "\#\{\$all-text-inputs-hover} { background: yellow; }"
     "all text inputs focus":
         "prefix": "all-text-inputs-focus"
-        "body": '#{$all-text-inputs-focus} { background: white; }'
+        "body": "\#\{\$all-text-inputs-focus} { background: white; }"
     "inline block":
         "prefix": "inline-block"
         "body": "@include inline-block;"


### PR DESCRIPTION
Updated `package.json` syntax to remove the deprecation warning for `activationEvents`

Added escape for characters in the `addons.cson` file
